### PR TITLE
Fix timestamp loosing trailing 0

### DIFF
--- a/utils/data_parser.py
+++ b/utils/data_parser.py
@@ -201,7 +201,7 @@ class DataParser:
             traj_timestamp = line.split(" ")[0]
 
             if pose_source == "colmap":
-                poses_from_traj[f"{float(traj_timestamp)}"] = np.array(self.TrajStringToMatrix(line)[1].tolist())
+                poses_from_traj[f"{traj_timestamp}"] = np.array(self.TrajStringToMatrix(line)[1].tolist())
             elif pose_source == "arkit":
                 poses_from_traj[f"{round(float(traj_timestamp), 3):.3f}"] = np.array(self.TrajStringToMatrix(line)[1].tolist())
 


### PR DESCRIPTION
There's a timestamp format inconsistency. When using "colmap" as the pose source, timestamps are converted to float. This causes timestamps like "3081.960" to become "3081.96", removing trailing zeros. Meanwhile, other methods like get_rgb_frames preserve the original string format of timestamps. This inconsistency makes it impossible to properly match timestamps between different data sources